### PR TITLE
Use SQLite as default development database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+quick_orders.db
 
 # Flask stuff:
 instance/

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ source venv/Scripts/activate
 # Install Python dependencies
 pip install -r requirements-simple.txt
 
-# Create MySQL database
-mysql -u root -p
-CREATE DATABASE `quick-orders`;
+# (Optional) Create external database
+# By default the app stores data in quick_orders.db (SQLite file)
+# mysql -u root -p
+# CREATE DATABASE `quick-orders`;
 ```
 
 ### 2. Configure Environment
@@ -64,6 +65,7 @@ CREATE DATABASE `quick-orders`;
 cp env.example .env
 
 # Edit configuration file if needed
+# Leave DATABASE_URL empty to use the bundled SQLite database
 # DATABASE_URL=mysql+pymysql://root:password@localhost/quick-orders
 ```
 

--- a/config.py
+++ b/config.py
@@ -1,27 +1,43 @@
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
 load_dotenv()
 
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def _default_database_url() -> str:
+    """Return the default database URL used when DATABASE_URL is not set."""
+
+    db_path = BASE_DIR / 'quick_orders.db'
+    return f"sqlite:///{db_path}"
+
+
 class Config:
     """基础配置类"""
+
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-key-change-in-production'
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or _default_database_url()
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    
+
     # 图片上传配置
     UPLOAD_FOLDER = 'static/uploads'
     MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB max file size
     ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp'}
 
+
 class DevelopmentConfig(Config):
     """开发环境配置"""
+
     DEBUG = True
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or 'mysql+pymysql://root:@localhost/quick-orders'
+
 
 class ProductionConfig(Config):
     """生产环境配置"""
+
     DEBUG = False
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or 'mysql+pymysql://root:@localhost/quick-orders'
 
 class TestingConfig(Config):
     """测试环境配置"""

--- a/env.example
+++ b/env.example
@@ -1,3 +1,4 @@
 SECRET_KEY=your-secret-key-here
-DATABASE_URL=mysql+pymysql://root:@localhost/quick-orders
+# Leave DATABASE_URL empty to use quick_orders.db (SQLite)
+DATABASE_URL=
 FLASK_ENV=development


### PR DESCRIPTION
## Summary
- fall back to a bundled SQLite database when DATABASE_URL is unset so the shop can restart with persisted data
- document the new default in the README and environment template for easier setup
- ignore the generated SQLite database file in version control

## Testing
- python - <<'PY'
from application import create_app
from flask import current_app

app = create_app()
with app.app_context():
    print('SQLALCHEMY_DATABASE_URI:', current_app.config['SQLALCHEMY_DATABASE_URI'])
PY


------
https://chatgpt.com/codex/tasks/task_e_68e2849e25788323965ec0a5c736aaf5